### PR TITLE
Bilevel refs and others

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -78,7 +78,472 @@
   Date-modified = {2026-04-09}
 }
 
+@book{Dempe2002,
+  Author        = {S. Dempe},
+  Title         = {Foundations of bilevel programming},
+  Publisher     = {Springer},
+  Year          = {2002},
+  Doi           = {10.1007/b101970},
+  Url           = {https://doi.org/10.1007/b101970},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} 
+
+@book{Du1995minimax,
+  Author        = {D.Z. Du and P.M. Pardalos},
+  Title         = {Minimax and applications},
+  Publisher     = {Springer Science \& Business Media},
+  Year          = {1995},
+  Doi           = {10.1007/978-1-4613-3557-3},
+  Url           = {https://doi.org/10.1007/978-1-4613-3557-3},
+  Date-added    = {2026-04-16},
+  Date-modified = {2026-04-16}
+} % Minimax Book
+
 %-----------------------------%
+
+@article{Jones1993,
+  Author        = {D.R. Jones and C.D. Perttunen and B.E. Stuckman},
+  Title         = {Lipschitzian optimization without the Lipschitz constant},
+  Journal       = {Journal of optimization Theory and Applications},
+  Volume        = {79},
+  Number        = {1},
+  Pages         = {157--181},
+  Year          = {1993},
+  Doi           = {10.1007/BF00941892},
+  Url           = {https://doi.org/10.1007/BF00941892},
+  Date-added    = {2026-04-19},
+  Date-modified = {2026-04-19}
+} % added by V. Dijon
+
+@article{HaOs2001,
+  Author        = {N. Hansen and A. Ostermeier},
+  Title         = {{Completely derandomized self-adaptation in evolution strategies}},
+  Journal       = {Evolutionary computation},
+  Volume        = {9},
+  Number        = {2},
+  Pages         = {159--195},
+  Year          = {2001},
+  Doi           = {10.1162/106365601750190398},
+  Url           = {https://doi.org/10.1162/106365601750190398},
+  Date-added    = {2026-04-19},
+  Date-modified = {2026-04-19}
+} % added by V. Dijon
+
+@article{WaBi2006,
+  Author        = {A. W{\"a}chter and L.T. Biegler},
+  Title         = {{On the implementation of an interior-point filter line-search algorithm for large-scale nonlinear programming}},
+  Journal       = {Mathematical programming},
+  Volume        = {106},
+  Number        = {1},
+  Pages         = {25--57},
+  Year          = {2006},
+  Doi           = {10.1007/s10107-004-0559-y},
+  Url           = {https://doi.org/10.1007/s10107-004-0559-y},
+  Date-added    = {2026-04-19},
+  Date-modified = {2026-04-19}
+} % added by V. Dijon
+
+@article{Sinha2014,
+  Author        = {A. Sinha and P. Malo and K. Deb},
+  Title         = {{Test problem construction for single-objective bilevel optimization}},
+  Journal       = {Evolutionary computation},
+  Volume        = {22},
+  Number        = {3},
+  Pages         = {439--477},
+  Year          = {2014},
+  Doi           = {10.1162/EVCO_a_00116},
+  Url           = {http://doi.org/10.1162/EVCO_a_00116},
+  Date-added    = {2026-04-19},
+  Date-modified = {2026-04-19}
+} % added by V. Dijon
+
+@article{Zhou2021,
+  Author        = {S. Zhou and A.B. Zemkoho and A. Tin},
+  Title         = {{{BOLIB}: bilevel optimization {LIB}rary of test problems}},
+  Journal       = {Bilevel Optimization: Advances and Next Challenges},
+  Volume        = {161},
+  Pages         = {563--580},
+  Year          = {2020},
+  Doi           = {10.1007/978-3-030-52119-6_19},
+  Url           = {https://doi.org/10.1007/978-3-030-52119-6_19},
+  Date-added    = {2026-04-19},
+  Date-nodified = {2026-04-19}
+} % added by V. Dijon
+
+@article{Mitsos2008,
+  Author        = {A. Mitsos and P. Lemonidis and P.I. Barton},
+  Title         = {{Global solution of bilevel programs with a nonconvex inner program}},
+  Journal       = {Journal of Global Optimization},
+  Volume        = {42},
+  Number        = {4},
+  Pages         = {475--513},
+  Year          = {2008},
+  Doi           = {10.1007/s10898-007-9260-z},
+  Url           = {https://doi.org/10.1007/s10898-007-9260-z},
+  Date-added    = {2026-04-19},
+  Date-nodified = {2026-04-19}
+} % added by V. Dijon
+
+@article{Xia2018,
+  Author        ={Y. Xia and X. Liu and G. Du},
+  Title         = {{Solving bi-level optimization problems in engineering design using kriging models}},
+  Journal       = {Engineering Optimization},
+  Volume        = {50},
+  Number        = {5},
+  Pages         = {856--876},
+  Year          = {2018},
+  Doi           = {10.1080/0305215X.2017.1358711},
+  Url           = {https://doi.org/10.1080/0305215X.2017.1358711},
+  Date-added    = {2026-04-19},
+  Date-nodified = {2026-04-19}
+} % added by V. Dijon
+
+@article{Wang2016,
+  Author        = {Z. Wang and F. Hutter and M. Zoghi and D. Matheson and N. {De~Feitas}},
+  Title         = {{Bayesian optimization in a billion dimensions via random embeddings}},
+  Journal       = {Journal of Artificial Intelligence Research},
+  Volume        = {55},
+  Pages         = {361--387},
+  Year          = {2016},
+  Doi           = {10.1613/jair.4806},
+  Url           = {https://doi.org/10.1613/jair.4806},
+  Date-added    = {2026-04-19},
+  Date-nodified = {2026-04-19}
+} % added by V. Dijon
+
+@techreport{Cesaroni2026,
+  Author        = {E. Cesaroni and G. Liuzzi and S. Lucidi},
+  Title         = {{BILBO: BILevel Bayesian Optimization}},
+  Institution   = {arXiv},
+  Number        = {2603.20759},
+  Year          = {2026},
+  Arxivurl      = {https://doi.org/10.48550/arXiv.2603.20759},
+  Url           = {https://doi.org/10.48550/arXiv.2603.20759},
+  Date-Added    = {2026-04-17},
+  Date-Modified = {2026-04-17}
+} % added by V. Dijon
+
+@inproceedings{Islam2018,
+  Author        = {M.M. Islam and H.K. Singh and T. Ray},
+  Booktitle     = {2018 IEEE congress on evolutionary computation (CEC)},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17},
+  Doi           = {10.1109/CEC.2018.8477714},
+  Publisher     = {IEEE},
+  Title         = {{Efficient global optimization for solving computationally expensive bilevel optimization problems}},
+  Url           = {https://doi.org/10.1109/CEC.2018.8477714},
+  Pages         = {1--8},
+  Year          = {2018}
+} % added by V. Dijon
+
+@article{Islam2017,
+  Author        = {M.M. Islam and H.K. Singh and T. Ray},
+  Title         = {{A surrogate assisted approach for single-objective bilevel optimization}},
+  Journal       = {IEEE Transactions on Evolutionary Computation},
+  Volume        = {21},
+  Number        = {5},
+  Pages         = {681--696},
+  Year          = {2017},
+  Doi           = {10.1109/TEVC.2017.2670659},
+  Url           = {htps://doi.org/10.1109/TEVC.2017.2670659},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@inproceedings{MaHu2025,
+  Author        = {Z. Ma and Z. Huang and J. Chen and Z. Cao and Y.J. Gong},
+  Booktitle     = {{Proceedings of the Genetic and Evolutionary Computation Conference}},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17},
+  Doi           = {10.1145/3712256.3726316},
+  Publisher     = {Association for Computing Machinery},
+  Title         = {{Surrogate learning in meta-black-box optimization: A preliminary study}},
+  Url           = {https://doi.org/10.1145/3712256.3726316},
+  Pages         = {1137--1145},
+  Year          = {2025}
+} % added by V. Dijon
+
+@article{Jiang2023,
+  Author        = {H. Jiang and K. Chou and Y. Tian and X. Zhang and Y. Jin},
+  Title         = {{Efficient surrogate modeling method for evolutionary algorithm to solve bilevel optimization problems}},
+  Journal       = {IEEE transactions on cybernetics},
+  Volume        = {54},
+  Number        = {7},
+  Pages         = {4335--4347},
+  Year          = {2023},
+  Doi           = {10.1109/TCYB.2023.3309598},
+  Url           = {https://doi.org/10.1109/TCYB.2023.3309598},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@inproceedings{Sinha2018,
+  Author        = {A. Sinha and S. Bedi and K. Deb},
+  Booktitle     = {{2018 IEEE congress on evolutionary computation (CEC)}},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17},
+  Doi           = {10.1109/CEC.2018.8477763},
+  Publisher     = {IEEE},
+  Title         = {{Bilevel optimization based on kriging approximations of lower level optimal value function}},
+  Url           = {https://doi.org/10.1109/CEC.2018.8477763},
+  Pages         = {1--8},
+  Year          = {2018}
+} % added by V. Dijon
+
+@article{SiSh2021,
+  Author        = {A. Sinha and V. Shaikh},
+  Title         = {{Solving bilevel optimization problems using kriging approximations}},
+  Journal       = {IEEE Transactions on Cybernetics},
+  Volume        = {52},
+  Number        = {10},
+  Pages         = {10639--10654},
+  Year          = {2021},
+  Doi           = {10.1109/TCYB.2021.3061551},
+  Url           = {https://doi.org/10.1109/TCYB.2021.3061551},
+  Date-added    = {2026-04-17},
+  date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@inproceedings{Man2025,
+  Author        = {T. Man and X. Li and Z. Liu and H. Zhang and B. Gu and Y. Chang},
+  Booktitle     = {{Proceedings of the 31st ACM SIGKDD Conference on Knowledge Discovery and Data Mining V. 1}},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17},
+  Doi           = {10.1145/3690624.3709265},
+  Publisher     = {Association for Computing Machinery},
+  Title         = {{Enhancing Black-Box Adversarial Attacks on Discrete Sequential Data via Bilevel Bayesian Optimization in Hybrid Spaces}},
+  Url           = {https://doi.org/10.1145/3690624.3709265},
+  Pages         = {1032--1043},
+  Year          = {2025}
+} % added by V. Dijon
+
+@techreport{Chew2025,
+  Author        = {R.W.T. Chew and Q.P. Nguyen and B.K.H. Low},
+  Title         = {{BILBO: BILevel Bayesian Optimization}},
+  Institution   = {arXiv},
+  Number        = {2502.02121},
+  Year          = {2025},
+  Arxivurl      = {https://doi.org/10.48550/arXiv.2502.02121},
+  Url           = {https://doi.org/10.48550/arXiv.2502.02121},
+  Date-Added    = {2026-04-17},
+  Date-Modified = {2026-04-17}
+} % added by V. Dijon
+
+@article{AgGh2025,
+  Author        = {A. Aghasi and S. Ghadimi},
+  Title         = {{Fully zeroth-order bilevel programming via Gaussian smoothing}},
+  Journal       = {Journal of Optimization Theory and Applications},
+  Volume        = {205},
+  Number        = {31},
+  Year          = {2025},
+  Doi           = {10.1007/s10957-025-02647-y},
+  Url           = {https://doi.org/10.1007/s10957-025-02647-y},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@techreport{Maheshwari2023,
+  Author        = {C. Maheshwari and S.S. Sasty and L. Ratliff and E. Mazumdar},
+  Title         = {{Convergent first-order methods for bi-level optimization and stackelberg games}},
+  Institution   = {arXiv},
+  Number        = {2302.01421},
+  Year          = {2023},
+  Arxivurl      = {https://doi.org/10.48550/arXiv.2302.01421},
+  Url           = {https://doi.org/10.48550/arXiv.2302.01421},
+  Date-Added    = {2026-04-17},
+  Date-Modified = {2026-04-17}
+} % added by V. Dijon
+
+@inproceedings{Kieffer2017,
+  Author        = {E. Kieffer and G. Danoy and P. Bouvry and A. Nagih},
+  Booktitle     = {{Proceedings of the genetic and evolutionary computation conference companion}},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17},
+  Doi           = {10.1145/3067695.3082537},
+  Publisher     = {Association for Computing Machinery},
+  Title         = {{Bayesian optimization approach of general bi-level problems}},
+  Url           = {https://doi.org/10.1145/3067695.3082537},
+  Pages         = {1614--1621},
+  Year          = {2017}
+} % added by V. Dijon
+
+@article{ZhLi2014,
+  Author        = {D. Zhang and G.H. Lin},
+  Title         = {{Bilevel direct search method for leader–follower problems and application in health insurance}},
+  Journal       = {Computers and Operations Research},
+  Volume        = {41},
+  Pages         = {359-373},
+  Year          = {2014},
+  Doi           = {10.1016/j.cor.2012.12.005},
+  Url           = {https://doi.org/10.1016/j.cor.2012.12.005},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@article{Nguyen2019,
+  Author        = {V.Q. Nguyen and R.T. Johnson and F.C. Sup and B.R. Umberger},
+  Title         = {{Bilevel optimization for cost function determination in dynamic simulation of human gait}},
+  Journal       = {IEEE Transactions on Neural Systems and Rehabilitation Engineering},
+  Volume        = {27},
+  Number        = {7},
+  Pages         = {1426--1435},
+  Year          = {2019},
+  Doi           = {10.1109/TNSRE.2019.2922942},
+  Url           = {https://doi.org/10.1109/TNSRE.2019.2922942},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@inproceedings{DoPr2022,
+  Author        = {V. Dogan and S. Prestwich},
+  Booktitle     = {{Irish Conference on Artificial Intelligence and Cognitive Science}},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17},
+  Doi           = {10.1007/978-3-031-26438-2_32},
+  Publisher     = {Cham: Springer},
+  Title         = {{Bayesian optimization with multi-objective acquisition function for bilevel problems}},
+  Url           = {https://doi.org/10.1007/978-3-031-26438-2_32},
+  Volume        = {1662},
+  Year          = {2022}
+} % added by V. Dijon
+
+@inproceedings{DoPr2023,
+  Author        = {V. Dogan and S. Prestwich},
+  Booktitle     = {{International Conference on Machine Learning, Optimization, and Data Science}},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17},
+  Doi           = {10.1007/978-3-031-53969-5_19},
+  Publisher     = {Cham: Springer},
+  Title         = {{Bilevel optimization by conditional Bayesian optimization}},
+  Url           = {https://doi.org/10.1007/978-3-031-53969-5_19},
+  Volume        = {14505},
+  Year          = {2023}
+} % added by V. Dijon
+
+@article{Staudigl2025,
+  Author        = {M. Staudigl and S. Weissmann and T. {Van~Leeuwen}},
+  Title         = {{Derivative-free stochastic bilevel optimization for inverse problems}},
+  Journal       = {Computational Optimization and Applications},
+  Volume        = {93},
+  Number        = {3},
+  Pages         = {967--1021},
+  Year          = {2025},
+  Doi           = {10.1007/s10589-025-00745-1},
+  Url           = {https://doi.org/10.1007/s10589-025-00745-1},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@article{EhRo2021,
+  Author        = {M.J. Ehrhardt and L. Roberts},
+  Title         = {Inexact derivative-free optimization for bilevel learning},
+  Journal       = {Journal of mathematical imaging and vision},
+  Volume        = {63},
+  Number        = {5},
+  Pages         = {580--600},
+  Year          = {2021},
+  Doi           = {10.1007/s10851-021-01020-8},
+  Url           = {https://doi.org/10.1007/s10851-021-01020-8},
+  Date-added    = {2026/04/17},
+  Date-modified = {2026/04/17}
+} % added by V. Dijon
+
+@article{CoVi2012,
+  Author        = {A.R. Conn and L.N. Vicente},
+  Title         = {{Bilevel derivative-free optimization and its application to robust optimization}},
+  Journal       = {Optimization Methods and Software},
+  Volume        = {27},
+  Number        = {3},
+  Pages         = {561--577},
+  Year          = {2012},
+  Doi           = {10.1080/10556788.2010.547579},
+  Url           = {https://doi.org/10.1080/10556788.2010.547579},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@article{MeDe2011,
+  Author        = {A.G. Mersha and S. Dempe},
+  Title         = {{Direct search algorithm for bilevel programming problems}},
+  Journal       = {Computational Optimization and Applications},
+  Volume        = {49},
+  Number        = {1},
+  Pages         = {1--15},
+  Year          = {2011},
+  Doi           = {10.1007/s10589-009-9295-9},
+  Url           = {https://doi.org/10.1007/s10589-009-9295-9},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@article{Diouane2024,
+  Author        = {Y. Diouane and V. Kungurtsev and R. Rinaldi and D. Zeffiro},
+  Title         = {{Inexact direct-search methods for bilevel optimization problems}},
+  Journal       = {Computational Optimization and Applications},
+  Volume        = {88},
+  Number        = {2},
+  Pages         = {469--490},
+  Year          = {2024},
+  Doi           = {10.1007/s10589-024-00567-7},
+  Url           = {https://doi.org/10.1007/s10589-024-00567-7},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@techreport{Ekmekcioglu2024,
+  Author        = {O. Ekmekcioglu and N. Aydin and J. Branke},
+  Title         = {{Bayesian Optimization of Bilevel Problems}},
+  Institution   = {arXiv},
+  Number        = {2412.18518},
+  Year          = {2024},
+  Arxivurl      = {https://doi.org/10.48550/arXiv.2412.18518},
+  Url           = {https://doi.org/10.48550/arXiv.2412.18518},
+  Date-Added    = {2026-04-17},
+  Date-Modified = {2026-04-17}
+} % added by V. Dijon
+
+@article{Heitsch2022,
+  Author        = {H. Heitsch and R. Henrion and T. Kleinert and M. Schmidt},
+  Title         = {{On convex lower-level black-box constraints in bilevel optimization with an application to gas market models with chance constraints}},
+  Journal       = {Journal of Global Optimization},
+  Volume        = {84},
+  Number        = {3},
+  Pages         = {651--685},
+  Year          = {2022},
+  Doi           = {10.1007/s10898-022-01161-z},
+  Url           = {https://doi.org/10.1007/s10898-022-01161-z},
+  Date-added    = {2026-04-17},
+  Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@article{Fliege2021,
+    Author        = {J. Fliege and A. Tin and A.B. Zemkoho},
+	Title         = {{{G}auss–{N}ewton-type methods for bilevel optimization}},
+    Journal       = {Computational Optimization and Applications},
+	Volume        = {78},
+    Number        = {3},
+    Pages         = {793--824},
+    Year          = {2021},
+    Doi           = {10.1007/s10589-020-00254-3},
+    Url           = {https://doi.org/10.1007/s10589-020-00254-3},
+    Date-added    = {2026-04-17},
+    Date-modified = {2026-04-17}
+} % added by V. Dijon
+
+@article{ZeZh2021,
+  Author        = {A.B. Zemkoho and S. Zhou},
+  Title         = {{Theoretical and numerical comparison of the {Karush}–{Kuhn}–{Tucker} and value function reformulations in bilevel optimization}},
+  Journal       = {Computational Optimization and Applications},
+  Volume        = {78},
+  Number        = {2},
+  Pages         = {625--674},
+  Year          = {2021},
+  Doi           = {10.1007/s10589-020-00250-7},
+  Url           = {https://doi.org/10.1007/s10589-020-00250-7},
+  Date-added    = {2026-04-16},
+  Date-modified = {2026-04-16}
+} % added by V. Dijon
 
 @article{HeFu06,
   Author  = {A.-R. Hedar and M. Fukushima},


### PR DESCRIPTION
This pull request aims for adding first references for bilevel (derivative-free) optimization. These references contain books about bilevel optimization, useful for BLO basics. Additionally, there are several references about bilevel first-order methods and bilevel derivative-free (BL-DFO) algorithms.

Other references that were helpful for my benchmarking paper are also added.